### PR TITLE
Adds link to Micronaut Problem Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,5 +394,10 @@ For more details check the [contribution guidelines](.github/CONTRIBUTING.md).
 
 ## Credits and references
 
-Users of the [Spring Framework] are highly encouraged to check out [Problems for Spring Web MVC]
-(https://github.com/zalando/problem-spring-web), a library that seemlessly integrates problems into Spring.
+### Spring Framework
+
+Users of the [Spring Framework](https://spring.io) are highly encouraged to check out [Problems for Spring Web MVC](https://github.com/zalando/problem-spring-web), a library that seemlessly integrates problems into Spring.
+
+### Micronaut Framework
+Users of the [Micronaut Framework](https://micronaut.io) are highly encouraged to check out [Micronaut Problem JSON
+](https://micronaut-projects.github.io/micronaut-problem-json/snapshot/guide/), a library that seemlessly integrates problems into Micronaut error processing.


### PR DESCRIPTION
## Description

Adds a link in the README.md file to integration of Problem+JSON with Micronaut Framework. 
<!--- Describe your changes in detail -->

## Motivation and Context

It allows users to discover that Problem+JSON can be easily used with Micronaut. 

## Types of changes

- Documentation